### PR TITLE
Introduce multi-level stateKey

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ This will allow you to generate tests on your reducer with a record button in th
 
 * **reducer** - the root reducer of your redux app, used in the generated test.
 * **includeReducer** - a boolean value, if true, a stringified version of your reducer will be incuded in your generated test, if false, a note to import reducer for testing will be added. defaults to false. Useful when used to generate actual tests so you can test updated functionality.
-* **stateKey(*optional*)** - if instead of recording the whole state you only want to record a specific piece, pass that here (useful with `actionSubset` prop explained next).
+* **stateKey(*optional*)** - if instead of recording the whole state you only want to record a specific piece, pass that here (useful with `actionSubset` prop explained next). To get to a -nth level child use dots, as in: `api.login.errors`.
 * **actionSubset(*optional*)** - allows you to record against a subset of actions instead of all actions. Useful combined with `stateKey` to test a single reducer.
 * **equality(*optional*)** - a function used to determine if the reducer returned correct state. Receives result of the reducer call and nextState returned during the flow of the application (**note, this api is in flux**). deafults to `===`. This argument can *also* be a *string*. This is useful if you want to call a function you will include in your test file, since calling external functions will not properly stringify that external function. 
 * **imports(*optional*)**` - a string argument where you can pass in other modules that you would like included iny our test file. Useful if you want to reference external functions in your equality check.

--- a/src/index.js
+++ b/src/index.js
@@ -1,12 +1,13 @@
 import createTest, { isTestLibrarySupported } from './create-test';
 
-const _returnChildState(stateKey, stateObj) => {
+const _returnChildState = (stateKey, stateObj) => {
   if (!stateKey) {
     return stateObj;
   };
   const splitState = stateKey.split('.');
-  return splitState.reduce((currentLevelObj, levelLabel) => {
-    return currentLevelObj[levelLabel] || {};
+  return splitState.reduce((higherLeveLobject, levelLabel) => {
+    const currentLevelObject = higherLeveLobject[levelLabel]
+    return currentLevelObject === undefined ? {} : currentLevelObject;
   }, stateObj);
 };
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,8 +1,8 @@
 import createTest, { isTestLibrarySupported } from './create-test';
 
 const reduxRecord = function({
-  reducer, 
-  includeReducer = false, 
+  reducer,
+  includeReducer = false,
   stateKey,
   actionSubset,
   equality = '(result, nextState) => result === nextState',
@@ -10,7 +10,7 @@ const reduxRecord = function({
   testLib = 'tape',
   numTestsToSave = 5,
   includeShowTestsButton = false
-}) { 
+}) {
   let actions = [];
   let recording = false;
   let showingTest = false;
@@ -33,7 +33,7 @@ const reduxRecord = function({
       listeners.forEach(fn => fn(newTestState));
     }
   }
-  
+
   // we can skip type checking to see if equality arg is a string since string.toString() returns same string
   const equalityFunction = equality.toString();
   const startRecord = () => {
@@ -71,7 +71,7 @@ const reduxRecord = function({
     throw new Error('testLib argument must be a string or a function');
   }
   if (typeof testLib === 'string' && !isTestLibrarySupported(testLib)) {
-    throw new Error('testLib argument does not contain a supported testing library. ' + 
+    throw new Error('testLib argument does not contain a supported testing library. ' +
       'Feel free to make a pr adding support or use a custom test generation function for testLib arg');
   }
 
@@ -113,11 +113,11 @@ const reduxRecord = function({
     updateListeners();
     return () => listeners.splice(listeners.splice(listeners.indexOf(fn), 1));
   }
-  const props = { 
-    startRecord, 
-    stopRecord, 
-    createNewTest, 
-    hideTest, 
+  const props = {
+    startRecord,
+    stopRecord,
+    createNewTest,
+    hideTest,
     showTest,
     emptyActions,
     updateTestIndex,

--- a/src/index.js
+++ b/src/index.js
@@ -1,13 +1,18 @@
 import createTest, { isTestLibrarySupported } from './create-test';
 
-const _returnChildState = (stateKey, stateObj) => {
+function getNestedState (stateKey, stateObj) {
   if (!stateKey) {
     return stateObj;
   };
   const splitState = stateKey.split('.');
   return splitState.reduce((higherLeveLobject, levelLabel) => {
-    const currentLevelObject = higherLeveLobject[levelLabel]
-    return currentLevelObject === undefined ? {} : currentLevelObject;
+    const currentLevelObject = higherLeveLobject[levelLabel];
+    if (currentLevelObject === undefined) {
+      throw new Error(
+        'Provided stateKey doesnt match the shape of the state object.'
+      );
+    };
+    return currentLevelObject;
   }, stateObj);
 };
 
@@ -107,9 +112,9 @@ const reduxRecord = function({
 
   const middleware = ({getState}) => (next) => (action) => {
     if (recording) {
-      const prevState = _returnChildState(stateKey, getState());
+      const prevState = getNestedState(stateKey, getState());
       next(action);
-      const nextState = _returnChildState(stateKey, getState());
+      const nextState = getNestedState(stateKey, getState());
       if (!actionSubset || actionSubset[action.type]) {
         actions.push({action, prevState, nextState});
       }

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,15 @@
 import createTest, { isTestLibrarySupported } from './create-test';
 
+const _returnChildState(stateKey, stateObj) => {
+  if (!stateKey) {
+    return stateObj;
+  };
+  const splitState = stateKey.split('.');
+  return splitState.reduce((currentLevelObj, levelLabel) => {
+    return currentLevelObj[levelLabel] || {};
+  }, stateObj);
+};
+
 const reduxRecord = function({
   reducer,
   includeReducer = false,
@@ -96,9 +106,9 @@ const reduxRecord = function({
 
   const middleware = ({getState}) => (next) => (action) => {
     if (recording) {
-      const prevState = stateKey ? getState()[stateKey] : getState();
+      const prevState = _returnChildState(stateKey, getState());
       next(action);
-      const nextState = stateKey ? getState()[stateKey] : getState();
+      const nextState = _returnChildState(stateKey, getState());
       if (!actionSubset || actionSubset[action.type]) {
         actions.push({action, prevState, nextState});
       }

--- a/tests/index.js
+++ b/tests/index.js
@@ -97,8 +97,8 @@ eval(state2.tests[0]);
 listen2();
 
 const record3 = reduxRecord({
-  reducer: add, 
-  includeReducer: false 
+  reducer: add,
+  includeReducer: false
 });
 
 test('reducer not included when includeReducer = false', assert => {
@@ -146,8 +146,8 @@ test('shouldShowTest is true after showTest is fired', assert => {
 test('extra imports are included when import arg is given', assert => {
   assert.plan(1);
   const record4 = reduxRecord({
-    reducer: add, 
-    imports: `var equal = reqire('deep-equal');` 
+    reducer: add,
+    imports: `var equal = reqire('deep-equal');`
   });
   const generatedTest = record4.props.createNewTest();
 
@@ -157,7 +157,7 @@ test('extra imports are included when import arg is given', assert => {
 test('it should generate a mocha test, when testLib arg === mocha', assert => {
   assert.plan(1);
   const record5 = reduxRecord({
-    reducer: reducer, 
+    reducer: reducer,
     testLib: 'mocha'
   });
   const generatedTest = record5.props.createNewTest();
@@ -167,7 +167,7 @@ test('it should generate a mocha test, when testLib arg === mocha', assert => {
 test('it should generate an ava test, when testLib arg === ava', assert => {
   assert.plan(1);
   const record6 = reduxRecord({
-    reducer: reducer, 
+    reducer: reducer,
     testLib: 'ava'
   });
   const generatedTest = record6.props.createNewTest();


### PR DESCRIPTION
As mentioned in https://github.com/conorhastings/redux-test-recorder/issues/37 , I prepared a working version of multi-level `stateKey` param.

I haven't written any tests so far having no prior experience with `tape`, but all the previous ones seem to work well. Would you like me to add some auto-generated ones by replicating lines `56-97` of `tests/index.js` with multi-level state? 